### PR TITLE
Update taxs main page with logic to correclty display SA or PAYE

### DIFF
--- a/app/views/taxs_main.scala.html
+++ b/app/views/taxs_main.scala.html
@@ -49,11 +49,21 @@
         @Messages("ats.index.html.title")<br>
         @Messages("generic.tax_year_heading", viewModel.taxYearFrom, viewModel.taxYearTo)
     </h1>
-    <p id="index-page-description">@Html(Messages("ats.index.html.lede"))</p>
-    <h2 class="heading-medium"><a id="tax-calc-link" href="@controllers.routes.SummaryController.authorisedSummaries()?taxYear=@viewModel.taxYearTo" data-journey-click="link - click:@Messages("ats.index.html.title"):@Messages("ats.index.html.tax_calc_link")">@Messages("ats.index.html.tax_calc_link")</a></h2>
-    <p>@Messages("ats.index.html.tax_calc_description")</p>
-    <h2 class="heading-medium"><a id="tax-services-link" href="@controllers.routes.GovernmentSpendController.authorisedGovernmentSpendData()?taxYear=@viewModel.taxYearTo" data-journey-click="link - click:@Messages("ats.index.html.title"):@Messages("ats.index.html.tax_spend_link")">@Messages("ats.index.html.tax_spend_link")</a></h2>
-    <p>@Messages("ats.index.html.tax_spend_description")</p>
+
+    @if(viewModel.isPaye){
+        <p id="index-page-description">@Html(Messages("ats.index.html.lede"))</p>
+        <h2 class="heading-medium"><a id="tax-calc-link" href="@controllers.routes.SummaryController.authorisedSummaries()?taxYear=@viewModel.taxYearTo" data-journey-click="link - click:@Messages("ats.index.html.title"):@Messages("ats.index.html.tax_calc_link")">@Messages("ats.index.html.tax_calc_link")</a></h2>
+        <p>@Messages("ats.index.html.tax_calc_description")</p>
+        <h2 class="heading-medium"><a id="tax-services-link" href="@controllers.routes.GovernmentSpendController.authorisedGovernmentSpendData()?taxYear=@viewModel.taxYearTo" data-journey-click="link - click:@Messages("ats.index.html.title"):@Messages("ats.index.html.tax_spend_link")">@Messages("ats.index.html.tax_spend_link")</a></h2>
+        <p>@Messages("ats.index.html.tax_spend_description")</p>
+    } else {
+        <p id="index-page-description">@Html(Messages("ats.sa.index.html.lede"))</p>
+        <h2 class="heading-medium"><a id="tax-calc-link" href="@controllers.routes.SummaryController.authorisedSummaries()?taxYear=@viewModel.taxYearTo" data-journey-click="link - click:@Messages("ats.index.html.title"):@Messages("ats.index.html.tax_calc_link")">@Messages("ats.index.html.tax_calc_link")</a></h2>
+        <p>@Messages("ats.sa.index.html.tax_calc_description")</p>
+        <h2 class="heading-medium"><a id="tax-services-link" href="@controllers.routes.GovernmentSpendController.authorisedGovernmentSpendData()?taxYear=@viewModel.taxYearTo" data-journey-click="link - click:@Messages("ats.index.html.title"):@Messages("ats.index.html.tax_spend_link")">@Messages("ats.sa.index.html.tax_spend_link")</a></h2>
+        <p>@Messages("ats.sa.index.html.tax_spend_description")</p>
+    }
+
     @if(request.session.get("TaxYearListLength").getOrElse("0") != "1"){
         <p><a href="@controllers.routes.IndexController.authorisedIndex()" data-journey-click="link - click:@Messages("ats.index.html.title"):@Messages("generic.back")">@Html(Messages("generic.back"))</a></p>
     }

--- a/conf/messages
+++ b/conf/messages
@@ -64,6 +64,12 @@ ats.index.html.tax_calc_description=This shows a breakdown of your taxable incom
 ats.index.html.tax_spend_link=How your tax was spent
 ats.index.html.tax_spend_description=This shows a breakdown of how your taxes have been spent by government.
 
+# SA variations
+ats.sa.index.html.lede=This summarises your personal tax and National Insurance, and how they are spent by government. This information comes from you, your employer(s) or your pension provider(s).
+ats.sa.index.html.tax_calc_description=This shows a breakdown of your total income, your tax-free amount, and how much tax and National Insurance you have paid or will pay.
+ats.sa.index.html.tax_spend_link=Your taxes and public spending
+ats.sa.index.html.tax_spend_description=This shows a breakdown of how your taxes have been, or will be spent by government.
+
 # View ATS - Summary
 #============================================================
 ats.summary.html.title=Your income and taxes

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -59,6 +59,12 @@ ats.index.html.tax_calc_description=Mae hwn yn dangos dadansoddiad o gyfanswm ei
 ats.index.html.tax_spend_link=Eich trethi a gwariant cyhoeddus
 ats.index.html.tax_spend_description=Mae hwn yn dangos dadansoddiad o sut mae’r llywodraeth wedi gwario eich trethi, neu sut y byddant yn gwneud hynny.
 
+# SA variations
+ats.sa.index.html.lede=Mae hwn yn crynhoi eich treth bersonol a’ch Yswiriant Gwladol, a sut mae’r llywodraeth yn eu gwario. Daw’r wybodaeth hon oddi wrthych chi, eich cyflogwr/cyflogwyr neu eich darparwr/darparwyr pensiwn.
+ats.sa.index.html.tax_calc_description=Mae hwn yn dangos dadansoddiad o gyfanswm eich incwm, eich swm yn rhydd o dreth, a faint o dreth ac Yswiriant Gwladol rydych wedi eu talu neu y byddwch yn eu talu.
+ats.sa.index.html.tax_spend_link=Eich trethi a gwariant cyhoeddus
+ats.sa.index.html.tax_spend_description=Mae hwn yn dangos dadansoddiad o sut mae’r llywodraeth wedi gwario eich trethi, neu sut y byddant yn gwneud hynny.
+
 # View ATS - Summary
 #============================================================
 ats.summary.html.title=Eich incwm a’ch trethi

--- a/test/controllers/ATSMainControllerSpec.scala
+++ b/test/controllers/ATSMainControllerSpec.scala
@@ -88,9 +88,9 @@ class ATSMainControllerSpec extends UnitSpec with GuiceOneAppPerSuite with Mocki
 
       status(result) shouldBe 200
       document.getElementById("tax-calc-link").text shouldBe "Your income and taxes"
-      document.getElementById("tax-services-link").text shouldBe "How your tax was spent"
+      document.getElementById("tax-services-link").text shouldBe "Your taxes and public spending"
       document.getElementById("index-page-header").text shouldBe "Your annual tax summary 6 April 2013 to 5 April 2014"
-      document.getElementById("index-page-description").text shouldBe "This shows you how your Income Tax and National Insurance contributions were calculated and how your money is spent by the government."
+      document.getElementById("index-page-description").text shouldBe "This summarises your personal tax and National Insurance, and how they are spent by government. This information comes from you, your employer(s) or your pension provider(s)."
       document.getElementById("tax-calc-link").tagName shouldBe "a"
       document.getElementById("tax-services-link").tagName shouldBe "a"
       document.getElementById("user-info").text should include("forename surname")

--- a/test/views/LanguageAgnosticSpec.scala
+++ b/test/views/LanguageAgnosticSpec.scala
@@ -93,8 +93,7 @@ class LanguageAgnosticSpec extends UnitSpec with OneServerPerSuite with OneBrows
       val result = views.html.taxs_main(fakeViewModel)(requestWithSession, messages, language, formPartialRetriever)
       val document = Jsoup.parse(contentAsString(result))
       document.getElementById("index-page-header").text() should include("Eich crynodeb treth blynyddol")
-      document.getElementById("index-page-description").text() shouldBe "Mae hwn yn crynhoi eich treth bersonol a’ch Yswiriant Gwladol, " +
-        "a sut mae’r llywodraeth yn eu gwario. Daw’r wybodaeth hon oddi wrthych chi, eich cyflogwr/cyflogwyr neu eich darparwr/darparwyr pensiwn."
+      document.getElementById("index-page-description").text() shouldBe "Mae hwn yn crynhoi eich treth bersonol a’ch Yswiriant Gwladol, a sut mae’r llywodraeth yn eu gwario. Daw’r wybodaeth hon oddi wrthych chi, eich cyflogwr/cyflogwyr neu eich darparwr/darparwyr pensiwn."
     }
 
     "show the treasury spending page in welsh language" in {


### PR DESCRIPTION
Update taxs main page with logic to correctly display SA or PAYE content appropriately.

I have:
- added in if/else logic to show different content for both SA and PAYE content
- included these additions in both English and Welsh messages files
- updated tests to match and pass

## SA version
<img width="1162" alt="Screenshot 2020-01-07 at 11 34 13" src="https://user-images.githubusercontent.com/1692222/71896204-04bc9f00-314b-11ea-9acb-83756001182b.png">


## PAYE version
<img width="1189" alt="Screenshot 2020-01-07 at 11 35 20" src="https://user-images.githubusercontent.com/1692222/71896216-0ab28000-314b-11ea-80d2-b2ceacc22da2.png">
